### PR TITLE
Update path to worker to work in safari

### DIFF
--- a/src/magickApi.ts
+++ b/src/magickApi.ts
@@ -111,26 +111,7 @@ function GetCurrentUrlDifferentFilename(fileName)
 }
 let currentJavascriptURL = './magickApi.js';
 
-// // instead of doing the sane code of being able to just use import.meta.url 
-// // (Edge doesn't work) (safari mobile, chrome, opera, firefox all do)
-// // 
-// // I will use stacktrace-js library to get the current file name
-// //
-// try {
-//   // @ts-ignore
-//   let packageUrl = import.meta.url;
-//   currentJavascriptURL = packageUrl;
-// } catch (error) {
-//   // eat
-// }
-//
-//
-{
-  let stacktrace = StackTrace.getSync();
-  currentJavascriptURL = stacktrace[0].fileName;
-}
-
-const magickWorkerUrl = GetCurrentUrlDifferentFilename('magick.js')
+const magickWorkerUrl = './magick.js';
 
 function GenerateMagickWorkerText(magickUrl){
   // generates code for the following


### PR DESCRIPTION
This fixes the path to the worker in Safari. In chrome you get the entire filename path from the statcktrace, in Safari you only get the filename
![image](https://user-images.githubusercontent.com/399068/73809898-e5d51b00-4791-11ea-8651-058bf009724f.png)
 and not the full path so it 404s when trying to load the worker. 

In chrome you get the full path 
![image](https://user-images.githubusercontent.com/399068/73810006-48c6b200-4792-11ea-8e2e-356354ec4852.png)


This replaces the path to the worker with a relative path.